### PR TITLE
Feature/implement-vanilla-scoping

### DIFF
--- a/Items.xml
+++ b/Items.xml
@@ -2628,7 +2628,7 @@
     <Projectile characterusable="false" launchimpulse="15.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
     <SkillRequirementHint identifier="medical" level="80" />
   </DevilsThirst-->
-  <Item name="Resuscitation Pack" identifier="respack" scale="0.5" category="Equipment" tags="smallitem,mobileradio,minizoom" cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light">
+  <Item name="Resuscitation Pack" identifier="respack" scale="0.5" category="Equipment" tags="smallitem,mobileradio" cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light">
     <Price baseprice="105">
       <Price storeidentifier="merchantoutpost" minavailable="3" />
       <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="10" />
@@ -9347,71 +9347,5 @@
       </MeleeWeapon>
       <SkillRequirementHint identifier="medical" level="25" />
     </Plastiseal>
-    <Item name="" identifier="headset" scale="0.5" category="Equipment" tags="smallitem,mobileradio,minizoom" description="" cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light">
-      <PreferredContainer primary="crewcab" secondary="divingcab" />
-      <Price baseprice="105">
-        <Price storeidentifier="merchantoutpost" minavailable="3" />
-        <Price storeidentifier="merchantcity" multiplier="0.9" minavailable="10" />
-        <Price storeidentifier="merchantresearch" minavailable="4" />
-        <Price storeidentifier="merchantmilitary" minavailable="6" />
-        <Price storeidentifier="merchantmine" minavailable="6" />
-      </Price>
-      <InventoryIcon texture="Content/Items/InventoryIconAtlas.png" sourcerect="256,0,64,64" origin="0.5,0.5" />
-      <Sprite name="Headset" texture="Content/Items/Jobgear/headgears.png" depth="0.6" sourcerect="28,321,49,62" origin="0.5,0.5" />
-      <Body radius="20" height="20" density="15" />
-      <Deconstruct time="10">
-        <Item identifier="plastic" amount="2" />
-        <Item identifier="copper" />
-      </Deconstruct>
-      <Fabricate suitablefabricators="fabricator" requiredtime="10">
-        <RequiredSkill identifier="mechanical" level="30" />
-        <RequiredItem identifier="plastic" />
-        <RequiredItem identifier="fpgacircuit" />
-      </Fabricate>
-      <WifiComponent range="35000.0" LinkToChat="true" MinChatMessageInterval="0.0">
-        <StatusEffect type="OnActive" targettype="This">
-          <Conditional JamTimer="gt 0" targetitemcomponent="WifiComponent" />
-          <sound file="Content/Sounds/RadioStatic.ogg" range="500.0" frequencymultiplier="0.7" loop="true" volume="0.5" />
-        </StatusEffect>
-      </WifiComponent>
-      <Upgrade gameversion="0.18.0.0">
-        <WifiComponent>
-          <RequiredItems items="" />
-        </WifiComponent>
-      </Upgrade>
-      <Wearable limbtype="Head" slots="Any,Headset" msg="ItemMsgPickUpSelect" displaycontainedstatus="true">
-        <sprite name="Headset Wearable" texture="Content/Items/Jobgear/headgears.png" limb="Head" depth="0.1" hidelimb="false" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.7" hideotherwearables="false" sourcerect="26,317,51,64" origin="0.5,0.6" />
-      </Wearable>
-    </Item>
-    <Item name="" identifier="autoinjectorheadset" scale="0.5" category="Equipment,Medical" tags="smallitem,mobileradio,minizoom" allowasextracargo="true" description="" cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light">
-      <PreferredContainer primary="medcab" />
-      <Price baseprice="140" sold="false">
-        <Price storeidentifier="merchantoutpost" />
-        <Price storeidentifier="merchantcity" multiplier="0.9" />
-        <Price storeidentifier="merchantresearch" />
-        <Price storeidentifier="merchantmilitary" />
-        <Price storeidentifier="merchantmine" />
-      </Price>
-      <InventoryIcon texture="Content/Items/JobGear/TalentGear.png" sourcerect="113,264,58,45" origin="0.5,0.5" />
-      <Sprite name="Headset" texture="Content/Items/JobGear/TalentGear.png" depth="0.6" sourcerect="255,305,72,60" origin="0.35,0.5" />
-      <Body radius="20" height="20" density="15" />
-      <Deconstruct time="10">
-        <Item identifier="plastic" amount="2" />
-        <Item identifier="copper" />
-      </Deconstruct>
-      <Fabricate suitablefabricators="fabricator" requiredtime="10" requiresrecipe="true">
-        <RequiredSkill identifier="mechanical" level="30" />
-        <RequiredItem identifier="plastic" />
-        <RequiredItem identifier="fpgacircuit" />
-      </Fabricate>
-      <WifiComponent range="35000.0" LinkToChat="true" MinChatMessageInterval="0.0" />
-      <ItemContainer capacity="1" maxstacksize="1" autoinject="true">
-        <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="384,448,64,64" origin="0.5,0.5" />
-        <Containable items="chem,syringe" />
-      </ItemContainer>
-      <Wearable limbtype="Head" slots="Any,Headset" msg="ItemMsgPickUpSelect" displaycontainedstatus="true">
-        <sprite name="Headset Wearable" texture="Content/Items/JobGear/TalentGear.png" sourcerect="255,305,72,58" limb="Head" hidelimb="false" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.7" hideotherwearables="false" origin="0.5,0.5" />
-      </Wearable>
-    </Item>
   </override>
 </Items>

--- a/Items.xml
+++ b/Items.xml
@@ -5473,7 +5473,7 @@
     <!-- Controller output was made editable in v1.1.4.0, disallow it on periscopes -->
     <Upgrade gameversion="1.1.4.0" allowingameediting="false" />
   </Item>
-  <Item name="Binoculars" identifier="binoculars" category="Medical,Material" Tags="smallitem,zoom,U.I" canbepicked="true" cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_metal_light">
+  <Item name="Binoculars" identifier="binoculars" category="Medical,Material" Tags="smallitem,U.I" canbepicked="true" cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_metal_light">
     <PreferredContainer primary="storagecab" />
     <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab" minamount="1" maxamount="2" spawnprobability="0.05" />
     <Price baseprice="10" sold="false">
@@ -5486,12 +5486,12 @@
     <InventoryIcon texture="%ModDir%/Sprites/items.png" sourcerect="538,852,138,46" origin="0.5,0.5" />
     <Sprite texture="%ModDir%/Sprites/items.png" sourcerect="538,852,138,46" depth="0.55" origin="0.5,0.5" />
     <Body width="45" height="30" density="20" />
-    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" aimpos="55,20" handle1="-25,-7" handle2="-25,-7" msg="ItemMsgPickUpSelect" />
+    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" aimpos="55,20" handle1="-25,-7" handle2="-25,-7" msg="ItemMsgPickUpSelect" cameraaimoffset="625" />
     <RangedWeapon spread="0" unskilledspread="6" combatPriority="10" drawhudwhenequipped="true" crosshairscale="0.2" reload="0.5" DualWieldReloadTimePenaltyMultiplier="1.75" DualWieldAccuracyPenalty="8">
       <CrosshairPointer texture="%ModDir%/Sprites/Binoculars-scope.png" sourcerect="0,0,7000,4000" />
     </RangedWeapon>
   </Item>
-  <Item name="Hand Binoculars" identifier="handbinoculars" category="Medical,Material" Tags="smallitem,zoom,U.I" canbepicked="true" cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_metal_light">
+  <Item name="Hand Binoculars" identifier="handbinoculars" category="Medical,Material" Tags="smallitem,U.I" canbepicked="true" cargocontaineridentifier="metalcrate" scale="0.5" impactsoundtag="impact_metal_light">
     <PreferredContainer primary="storagecab" />
     <PreferredContainer secondary="wreckstoragecab,abandonedstoragecab" minamount="1" maxamount="2" spawnprobability="0.05" />
     <Price baseprice="10" sold="false">
@@ -5504,7 +5504,7 @@
     <InventoryIcon texture="%ModDir%/Sprites/Binoculars-hands.png" sourcerect="0,0,0,0" origin="0.5,0.5" />
     <Sprite texture="%ModDir%/Sprites/Binoculars-hands.png" sourcerect="0,0,0,0" depth="0.55" origin="0.5,0.5" />
     <Body width="45" height="30" density="20" />
-    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" aimpos="55,20" handle1="-25,-7" handle2="-25,-7" msg="ItemMsgPickUpSelect" />
+    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" aimpos="55,20" handle1="-25,-7" handle2="-25,-7" msg="ItemMsgPickUpSelect" cameraaimoffset="625" />
     <RangedWeapon spread="0" unskilledspread="6" combatPriority="10" drawhudwhenequipped="true" crosshairscale="0.2" reload="0.5" DualWieldReloadTimePenaltyMultiplier="1.75" DualWieldAccuracyPenalty="8">
       <CrosshairPointer texture="%ModDir%/Sprites/Binoculars-hands.png" sourcerect="0,0,1308,709" />
     </RangedWeapon>

--- a/Items.xml
+++ b/Items.xml
@@ -6208,7 +6208,7 @@
     </Quality>
     <SkillRequirementHint identifier="weapons" level="60" />
   </Item>
-  <Item name="XM3 (2x Scope)" identifier="xm3megazoom" aliases="sniperriflemegazoom" category="Weapon" cargocontaineridentifier="metalcrate" tags="mediumitem,weapon,gun,gunsmith,mountableweapon,megazoom" Scale="0.5" impactsoundtag="impact_metal_light">
+  <Item name="XM3 (2x Scope)" identifier="xm3megazoom" aliases="sniperriflemegazoom" category="Weapon" cargocontaineridentifier="metalcrate" tags="mediumitem,weapon,gun,gunsmith,mountableweapon" Scale="0.5" impactsoundtag="impact_metal_light">
     <PreferredContainer primary="secarmcab" amount="1" spawnprobability="1" notcampaign="true" />
     <PreferredContainer secondary="outpostsecarmcab" amount="1" spawnprobability="0.5" />
     <PreferredContainer secondary="wrecksecarmcab,abandonedsecarmcab" amount="1" spawnprobability="0.2" />
@@ -6235,7 +6235,7 @@
     </Fabricate>
     <Sprite texture="%ModDir%/Sprites/items.png" sourcerect="420,606,328,82" depth="0.55" origin="0.5,0.25" />
     <Body width="190" height="50" density="25" />
-    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" holdpos="120,0" aimpos="85,5" handle1="-80,-40" handle2="120,-40" holdangle="-40" msg="ItemMsgPickUpSelect">
+    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" holdpos="120,0" aimpos="85,5" handle1="-80,-40" handle2="120,-40" holdangle="-40" msg="ItemMsgPickUpSelect" cameraaimoffset="1250">
       <LightComponent LightColor="255,0,0,255" directional="true" Flicker="0" range="1600" powerconsumption="0" minvoltage="0" IsOn="true">
         <LightTexture texture="%ModDir%/Sprites/lasersight.png" origin="0.0, 0.5" size="2.0,0.25" />
       </LightComponent>

--- a/Items.xml
+++ b/Items.xml
@@ -2734,7 +2734,7 @@
     <Projectile characterusable="false" launchimpulse="18.0" sticktocharacters="true" launchrotation="-90" inheritstatuseffectsfrom="MeleeWeapon" inheritrequiredskillsfrom="MeleeWeapon" />
     <SkillRequirementHint identifier="medical" level="100" />
   </adrenalineshot>
-  <Item name="UMP-9" identifier="ump9" category="Weapon" cargocontaineridentifier="metalcrate" tags="smallautoweapon,smallitem,weapon,gun,gunsmith,mountableweapon,minizoom" Scale="0.3" impactsoundtag="impact_metal_light">
+  <Item name="UMP-9" identifier="ump9" category="Weapon" cargocontaineridentifier="metalcrate" tags="smallautoweapon,smallitem,weapon,gun,gunsmith,mountableweapon" Scale="0.3" impactsoundtag="impact_metal_light">
     <PreferredContainer primary="secarmcab" amount="1" spawnprobability="1" notcampaign="true" />
     <PreferredContainer secondary="outpostsecarmcab" amount="1" spawnprobability="0.5" />
     <PreferredContainer secondary="wrecksecarmcab,abandonedsecarmcab" amount="1" spawnprobability="0.25" />
@@ -2759,7 +2759,7 @@
     <InventoryIcon texture="%ModDir%/Sprites/items.png" sourcerect="885,117,301,96" origin="0.5,0.5" />
     <Sprite texture="%ModDir%/Sprites/items.png" sourcerect="885,117,301,96" depth="0.55" origin="0.5,0.5" />
     <Body width="140" height="60" density="25" />
-    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" holdpos="40,-10" aimpos="45,-10" handle1="-55,-15" handle2="60,20" holdangle="-35" msg="ItemMsgPickUpSelect" />
+    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" holdpos="40,-10" aimpos="45,-10" handle1="-55,-15" handle2="60,20" holdangle="-35" msg="ItemMsgPickUpSelect" cameraaimoffset="350" />
     <RangedWeapon reload="0.15" weapondamagemodifier="1.3" penetration="0.25" holdtrigger="true" barrelpos="140,20" spread="4" unskilledspread="16" combatPriority="80" drawhudwhenequipped="true" crosshairscale="0.2">
       <Crosshair texture="Content/Items/Weapons/Crosshairs.png" sourcerect="0,256,256,256" />
       <CrosshairPointer texture="Content/Items/Weapons/Crosshairs.png" sourcerect="256,256,256,256" />
@@ -4775,7 +4775,7 @@
       <input name="signal_in" displayname="connection.signalin" />
     </ConnectionPanel>
   </Item>
-  <Item name="AA-12" identifier="AA-12" category="Weapon" cargocontaineridentifier="metalcrate" allowasextracargo="true" tags="mediumitem,weapon,gun,gunsmith,mountableweapon,minizoom" Scale="0.62" impactsoundtag="impact_metal_light">
+  <Item name="AA-12" identifier="AA-12" category="Weapon" cargocontaineridentifier="metalcrate" allowasextracargo="true" tags="mediumitem,weapon,gun,gunsmith,mountableweapon" Scale="0.62" impactsoundtag="impact_metal_light">
     <PreferredContainer primary="secarmcab" secondary="armcab,weaponholder" />
     <Price baseprice="710" sold="false">
       <Price storeidentifier="merchantoutpost" multiplier="1.4" />
@@ -4799,7 +4799,7 @@
     </Deconstruct>
     <Sprite texture="%ModDir%/Sprites/items.png" sourcerect="418,4,185,61" depth="0.70" origin="0.5,0.5" />
     <Body width="100" height="25" density="25" />
-    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" holdpos="120,-20" aimpos="120,-5" handle1="-12,-15" handle2="20,5" holdangle="-20" msg="ItemMsgPickUpSelect">
+    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" holdpos="120,-20" aimpos="120,-5" handle1="-12,-15" handle2="20,5" holdangle="-20" msg="ItemMsgPickUpSelect" cameraaimoffset="350">
       <StatusEffect type="OnActive" target="Character" SpeedMultiplier="0.9" setvalue="true" />
     </Holdable>
     <RangedWeapon barrelpos="68,10" weapondamagemodifier="1.3" spread="6.0" unskilledspread="7" combatPriority="80" reload="0.8" holdtrigger="true" drawhudwhenequipped="true" crosshairscale="0.2">
@@ -4831,7 +4831,7 @@
     </Quality>
     <SkillRequirementHint identifier="weapons" level="60" />
   </Item>
-  <Item name="Triple-Barreled Shotgun" identifier="tripleshotgun" category="Weapon" cargocontaineridentifier="metalcrate" tags="mediumitem,weapon,gun,gunsmith,mountableweapon,minizoom" Scale="0.5" impactsoundtag="impact_metal_light">
+  <Item name="Triple-Barreled Shotgun" identifier="tripleshotgun" category="Weapon" cargocontaineridentifier="metalcrate" tags="mediumitem,weapon,gun,gunsmith,mountableweapon" Scale="0.5" impactsoundtag="impact_metal_light">
     <PreferredContainer primary="secarmcab" amount="1" spawnprobability="1" notcampaign="true" />
     <PreferredContainer secondary="outpostsecarmcab" amount="1" spawnprobability="0.5" />
     <PreferredContainer secondary="wrecksecarmcab,abandonedsecarmcab" amount="1" spawnprobability="0.2" />
@@ -4859,7 +4859,7 @@
     <InventoryIcon texture="%ModDir%/Sprites/items.png" sourcerect="425,120,296,60" origin="0.5,0.5" />
     <Sprite texture="%ModDir%/Sprites/items.png" sourcerect="425,120,296,60" depth="0.55" origin="0.5,0.25" />
     <Body width="360" height="60" density="25" />
-    <Holdable slots="Any,RightHand+LeftHand" weapondamagemodifier="1.1" controlpose="true" holdpos="40,-10" aimpos="55,5" handle1="-50,-16" handle2="50,0" holdangle="-40" msg="ItemMsgPickUpSelect" />
+    <Holdable slots="Any,RightHand+LeftHand" weapondamagemodifier="1.1" controlpose="true" holdpos="40,-10" aimpos="55,5" handle1="-50,-16" handle2="50,0" holdangle="-40" msg="ItemMsgPickUpSelect" cameraaimoffset="350" />
     <RangedWeapon barrelpos="85,5" spread="0.1" unskilledspread="7" combatPriority="80" reload="0" drawhudwhenequipped="true" crosshairscale="0.2">
       <Crosshair texture="Content/Items/Weapons/Crosshairs.png" sourcerect="0,256,256,256" />
       <CrosshairPointer texture="Content/Items/Weapons/Crosshairs.png" sourcerect="256,256,256,256" />
@@ -4973,7 +4973,7 @@
     <aitarget sightrange="5000" soundrange="500" fadeouttime="5" />
     <SkillRequirementHint identifier="weapons" level="50" />
   </Item>
-  <Item name="M-79" identifier="m-79" category="Weapon" cargocontaineridentifier="metalcrate" tags="mediumitem,weapon,gun,gunsmith,provocativetohumanai,mountableweapon,minizoom" Scale="0.5" impactsoundtag="impact_metal_light">
+  <Item name="M-79" identifier="m-79" category="Weapon" cargocontaineridentifier="metalcrate" tags="mediumitem,weapon,gun,gunsmith,provocativetohumanai,mountableweapon" Scale="0.5" impactsoundtag="impact_metal_light">
     <PreferredContainer primary="secarmcab" amount="1" spawnprobability="0.2" notcampaign="true" />
     <PreferredContainer secondary="wrecksecarmcab,abandonedsecarmcab,piratesecarmcab" spawnprobability="0.1" />
     <PreferredContainer secondary="armcab" />
@@ -4992,7 +4992,7 @@
     <InventoryIcon texture="%ModDir%/Sprites/items.png" sourcerect="536,401,185,63" origin="0.5,0.5" />
     <Sprite texture="%ModDir%/Sprites/items.png" sourcerect="536,401,185,63" depth="0.55" origin="0.5,0.5" />
     <Body width="170" height="40" density="25" />
-    <Holdable slots="RightHand+LeftHand,Any" controlpose="true" holdpos="40,-20" aimpos="45,-10" handle1="-33,-15" handle2="26,5" holdangle="-25" />
+    <Holdable slots="RightHand+LeftHand,Any" controlpose="true" holdpos="40,-20" aimpos="45,-10" handle1="-33,-15" handle2="26,5" holdangle="-25" cameraaimoffset="350" />
     <RangedWeapon barrelpos="80,11" reload="1.8" spread="1" unskilledspread="10" combatPriority="75" drawhudwhenequipped="true" crosshairscale="0.2">
       <Crosshair texture="Content/Items/Weapons/Crosshairs.png" sourcerect="0,256,256,256" />
       <CrosshairPointer texture="Content/Items/Weapons/Crosshairs.png" sourcerect="256,256,256,256" />
@@ -5155,7 +5155,7 @@
     </Projectile>
     <Upgrade gameversion="0.10.0.0" scale="0.5" />
   </Item>
-  <Item name="SR-3M" identifier="sr3m" category="Weapon" cargocontaineridentifier="metalcrate" tags="smallautoweapon,smallitem,weapon,gun,gunsmith,mountableweapon,minizoom" Scale="0.3" impactsoundtag="impact_metal_light">
+  <Item name="SR-3M" identifier="sr3m" category="Weapon" cargocontaineridentifier="metalcrate" tags="smallautoweapon,smallitem,weapon,gun,gunsmith,mountableweapon" Scale="0.3" impactsoundtag="impact_metal_light">
     <PreferredContainer primary="secarmcab" amount="1" spawnprobability="1" notcampaign="true" />
     <PreferredContainer secondary="outpostsecarmcab" amount="1" spawnprobability="0.5" />
     <PreferredContainer secondary="wrecksecarmcab,abandonedsecarmcab" amount="1" spawnprobability="0.25" />
@@ -5180,7 +5180,7 @@
     <InventoryIcon texture="%ModDir%/Sprites/items.png" sourcerect="739,456,396,107" origin="0.5,0.5" />
     <Sprite texture="%ModDir%/Sprites/items.png" sourcerect="739,456,396,107" depth="0.55" origin="0.5,0.5" />
     <Body width="140" height="60" density="25" />
-    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" holdpos="40,-10" aimpos="45,-10" handle1="-60,-15" handle2="80,5" holdangle="-35" msg="ItemMsgPickUpSelect" />
+    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" holdpos="40,-10" aimpos="45,-10" handle1="-60,-15" handle2="80,5" holdangle="-35" msg="ItemMsgPickUpSelect" cameraaimoffset="350" />
     <RangedWeapon reload="0.13" weapondamagemodifier="1.0" holdtrigger="true" barrelpos="140,20" spread="1" unskilledspread="6.4" combatPriority="80" drawhudwhenequipped="true" crosshairscale="0.2">
       <Crosshair texture="Content/Items/Weapons/Crosshairs.png" sourcerect="0,256,256,256" />
       <CrosshairPointer texture="Content/Items/Weapons/Crosshairs.png" sourcerect="256,256,256,256" />
@@ -5630,7 +5630,7 @@
     </Projectile>
     <Upgrade gameversion="0.10.0.0" scale="0.5" />
   </Item>
-  <Item name="Rusty Milkor MGL" identifier="milkor" category="Weapon" cargocontaineridentifier="metalcrate" tags="mediumitem,weapon,gun,gunsmith,provocativetohumanai,mountableweapon,minizoom" Scale="0.4" impactsoundtag="impact_metal_light">
+  <Item name="Rusty Milkor MGL" identifier="milkor" category="Weapon" cargocontaineridentifier="metalcrate" tags="mediumitem,weapon,gun,gunsmith,provocativetohumanai,mountableweapon" Scale="0.4" impactsoundtag="impact_metal_light">
     <PreferredContainer primary="secarmcab" amount="1" spawnprobability="0.2" notcampaign="true" />
     <PreferredContainer secondary="wrecksecarmcab,abandonedsecarmcab,piratesecarmcab" spawnprobability="0.1" />
     <PreferredContainer secondary="armcab" />
@@ -5649,7 +5649,7 @@
     <InventoryIcon texture="%ModDir%/Sprites/items.png" sourcerect="435,188,286,126" origin="0.5,0.5" />
     <Sprite texture="%ModDir%/Sprites/items.png" sourcerect="435,188,286,126" depth="0.55" origin="0.5,0.5" />
     <Body width="170" height="70" density="25" />
-    <Holdable slots="RightHand+LeftHand" controlpose="true" holdpos="40,-20" aimpos="45,-10" handle1="-40,-20" handle2="75,5" holdangle="-25" />
+    <Holdable slots="RightHand+LeftHand" controlpose="true" holdpos="40,-20" aimpos="45,-10" handle1="-40,-20" handle2="75,5" holdangle="-25" cameraaimoffset="350" />
     <Wearable slots="Bag" msg="ItemMsgEquipSelect" canbeselected="false" canbepicked="true" pickkey="Select">
       <sprite name="Milkor MGL Worn" texture="%ModDir%/Sprites/items.png" canbehiddenbyotherwearables="false" sourcerect="435,188,286,126" rotation="90" depth="0.4" limb="Torso" depthlimb="LeftArm" scale="0.5" origin="0.5,0.8" />
     </Wearable>
@@ -5944,7 +5944,7 @@
       </StatusEffect>
     </ItemComponent>
   </Item>
-  <Item name="M249" identifier="m249" category="Weapon" cargocontaineridentifier="metalcrate" allowasextracargo="true" tags="mediumitem,weapon,gun,gunsmith,mountableweapon,saboteurbonus,minizoom" Scale="0.5" impactsoundtag="impact_metal_light">
+  <Item name="M249" identifier="m249" category="Weapon" cargocontaineridentifier="metalcrate" allowasextracargo="true" tags="mediumitem,weapon,gun,gunsmith,mountableweapon,saboteurbonus" Scale="0.5" impactsoundtag="impact_metal_light">
     <PreferredContainer primary="secarmcab" secondary="armcab,weaponholder" />
     <Price baseprice="720" sold="false">
       <Price storeidentifier="merchantoutpost" multiplier="1.5" />
@@ -5967,7 +5967,7 @@
     <InventoryIcon texture="%ModDir%/Sprites/items.png" sourcerect="453,475,257,96" origin="0.5,0.5" />
     <Sprite texture="%ModDir%/Sprites/items.png" sourcerect="453,475,257,96" depth="0.55" origin="0.5,0.5" />
     <Body width="220" height="50" density="25" />
-    <Holdable slots="RightHand+LeftHand" controlpose="true" holdpos="45,-20" aimpos="57,-5" handle1="-35,-10" handle2="26,10" holdangle="-30">
+    <Holdable slots="RightHand+LeftHand" controlpose="true" holdpos="45,-20" aimpos="57,-5" handle1="-35,-10" handle2="26,10" holdangle="-30" cameraaimoffset="350">
       <StatusEffect type="OnActive" target="Character" SpeedMultiplier="0.8" setvalue="true" />
     </Holdable>
     <Wearable slots="Bag" msg="ItemMsgEquipSelect" canbeselected="false" canbepicked="true" pickkey="Select">
@@ -6121,7 +6121,7 @@
       </StatusEffect>
     </Projectile>
   </Item>
-  <Item name="XM3" identifier="xm3" aliases="sniperrifle" category="Weapon" cargocontaineridentifier="metalcrate" tags="mediumitem,weapon,gun,gunsmith,mountableweapon,zoom" Scale="0.5" impactsoundtag="impact_metal_light">
+  <Item name="XM3" identifier="xm3" aliases="sniperrifle" category="Weapon" cargocontaineridentifier="metalcrate" tags="mediumitem,weapon,gun,gunsmith,mountableweapon" Scale="0.5" impactsoundtag="impact_metal_light">
     <PreferredContainer primary="secarmcab" amount="1" spawnprobability="1" notcampaign="true" />
     <PreferredContainer secondary="outpostsecarmcab" amount="1" spawnprobability="0.5" />
     <PreferredContainer secondary="wrecksecarmcab,abandonedsecarmcab" amount="1" spawnprobability="0.2" />
@@ -6148,7 +6148,7 @@
     </Fabricate>
     <Sprite texture="%ModDir%/Sprites/items.png" sourcerect="420,606,328,82" depth="0.55" origin="0.5,0.25" />
     <Body width="190" height="50" density="25" />
-    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" holdpos="120,0" aimpos="85,5" handle1="-80,-40" handle2="120,-40" holdangle="-40" msg="ItemMsgPickUpSelect">
+    <Holdable slots="Any,RightHand+LeftHand" controlpose="true" holdpos="120,0" aimpos="85,5" handle1="-80,-40" handle2="120,-40" holdangle="-40" msg="ItemMsgPickUpSelect" cameraaimoffset="625">
       <LightComponent LightColor="255,0,0,255" directional="true" Flicker="0" range="1600" powerconsumption="0" minvoltage="0" IsOn="true">
         <LightTexture texture="%ModDir%/Sprites/lasersight.png" origin="0.0, 0.5" size="2.0,0.25" />
       </LightComponent>
@@ -8174,7 +8174,7 @@
         </StatusEffect>
       </Projectile>
     </Item>
-    <Item name="" identifier="rifle" category="Weapon" cargocontaineridentifier="metalcrate" tags="mediumitem,weapon,gun,gunsmith,provocativetohumanai,mountableweapon,minizoom" Scale="0.5" impactsoundtag="impact_metal_light">
+    <Item name="" identifier="rifle" category="Weapon" cargocontaineridentifier="metalcrate" tags="mediumitem,weapon,gun,gunsmith,provocativetohumanai,mountableweapon" Scale="0.5" impactsoundtag="impact_metal_light">
       <PreferredContainer primary="secarmcab" amount="1" spawnprobability="1" notcampaign="true" />
       <PreferredContainer secondary="outpostsecarmcab" amount="1" spawnprobability="0.5" />
       <PreferredContainer secondary="wrecksecarmcab,abandonedsecarmcab,piratesecarmcab" amount="1" spawnprobability="0.2" />
@@ -8201,7 +8201,7 @@
       </Fabricate>
       <Sprite texture="Content/Items/Weapons/weapons_new.png" sourcerect="254,2,200,55" depth="0.55" origin="0.5,0.25" />
       <Body width="190" height="50" density="25" />
-      <Holdable slots="Any,RightHand+LeftHand" controlpose="true" holdpos="40,-10" aimpos="55,5" handle1="-25,-16" handle2="26,0" holdangle="-40" msg="ItemMsgPickUpSelect" />
+      <Holdable slots="Any,RightHand+LeftHand" controlpose="true" holdpos="40,-10" aimpos="55,5" handle1="-25,-16" handle2="26,0" holdangle="-40" msg="ItemMsgPickUpSelect" cameraaimoffset="350" />
       <ItemComponent characterusable="true">
         <!-- define this here, because it won't work in RangedWeapon:
           the grenade has been fired and is no longer in the container when OnUse executes -->


### PR DESCRIPTION
Removed minizoom, zoom and megazoom tags and replaced them with vanilla scoping (cameraaimoffset, 350, 625 and 1250 respectively).
Removed headset overrides completely cause we only used them for adding minizoom tags and giving everyone minizoom is stupid.

Does NOT remove the lua itself.